### PR TITLE
don't launch each test as a separate process

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -16,7 +16,7 @@ set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 if(CUDA_ENABLED)
     set(CMAKE_CUDA_STANDARD 20)
-    set(CMAKE_CUDA_ARCHITECTURES 86)
+    set(CMAKE_CUDA_ARCHITECTURES native)
 endif() 
 
 if(NOT CMAKE_BUILD_TYPE)
@@ -117,25 +117,25 @@ file(GLOB TEST_FILES
 
 if(TEST_FILES)
     enable_testing()
-    add_executable(tests ${TEST_FILES})
 
-    target_include_directories(tests PRIVATE include)
-    target_link_libraries(tests PRIVATE tannic)
+    foreach(filename ${TEST_FILES})
 
-    if(CUDA_ENABLED)
-        set_target_properties(tests PROPERTIES
-            CUDA_SEPARABLE_COMPILATION ON
-            CUDA_STANDARD 20
-        )
-        target_link_libraries(tests PRIVATE CUDA::cudart)
-    endif()
+      get_filename_component(testname ${filename} NAME_WE)
+    
+      add_executable(${testname} ${filename})
+      target_include_directories(${testname} PRIVATE include)
+      target_link_libraries(${testname} PRIVATE tannic)
+      target_link_libraries(${testname} PUBLIC tannic GTest::gtest_main)
+    
+      if(CUDA_ENABLED)
+          set_target_properties(${testname} PROPERTIES
+              CUDA_SEPARABLE_COMPILATION ON
+              CUDA_STANDARD 20
+          )
+          target_link_libraries(${testname} PRIVATE CUDA::cudart)
+      endif()
 
-    if(GTest_FOUND)
-        target_link_libraries(tests PRIVATE GTest::gtest_main)
-    else()
-        target_link_libraries(tests PRIVATE gtest_main)
-    endif()
+      add_test(${testname} ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${testname})
 
-    include(GoogleTest)
-    gtest_discover_tests(tests)
+    endforeach(filename ${TEST_FILES})
 endif()


### PR DESCRIPTION
this is a response to your post on [/r/cuda](https://www.reddit.com/r/CUDA/comments/1nb8wt7/testing_a_c_tensor_library_is_to_slow_with_gtest/)

It looks like the ~150 tests here are each launched as separate processes, which means a lot of the CUDA setup costs are paid each time. This is a small change to the CMake specification that instead just creates a separate executable per translation unit (the entire test suite is still invoked by calling `ctest .` like before). That way, putting multiple tests in a single sourcefile only incurs the CUDA runtime setup cost once.

On my machine, the tests originally took around 12 seconds to finish, and now they complete in about 1 second:

```
~/code/Tannic/build$ ctest .
Test project /home/sam/code/Tannic/build
      Start  1: test-complex
 1/26 Test  #1: test-complex .....................   Passed    0.00 sec
      Start  2: test-concat
 2/26 Test  #2: test-concat ......................   Passed    0.01 sec
      Start  3: test-convolutions
 3/26 Test  #3: test-convolutions ................   Passed    0.01 sec
      Start  4: test-functions
 4/26 Test  #4: test-functions ...................   Passed    0.01 sec
      Start  5: test-matmul
 5/26 Test  #5: test-matmul ......................   Passed    0.02 sec
      Start  6: test-non-contiguous
 6/26 Test  #6: test-non-contiguous ..............   Passed    0.01 sec
      Start  7: test-operations
 7/26 Test  #7: test-operations ..................   Passed    0.00 sec
      Start  8: test-outer-product
 8/26 Test  #8: test-outer-product ...............   Passed    0.02 sec
      Start  9: test-reductions
 9/26 Test  #9: test-reductions ..................   Passed    0.01 sec
      Start 10: test-repeats
10/26 Test #10: test-repeats .....................   Passed    0.02 sec
      Start 11: test-scalars
11/26 Test #11: test-scalars .....................   Passed    0.01 sec
      Start 12: test-views
12/26 Test #12: test-views .......................   Passed    0.03 sec
      Start 13: test-cuda-allocations
13/26 Test #13: test-cuda-allocations ............   Passed    0.10 sec
      Start 14: test-cuda-complex
14/26 Test #14: test-cuda-complex ................   Passed    0.13 sec
      Start 15: test-cuda-concat
15/26 Test #15: test-cuda-concat .................   Passed    0.15 sec
      Start 16: test-cuda-convolutions
16/26 Test #16: test-cuda-convolutions ...........   Passed    0.13 sec
      Start 17: test-cuda-functions
17/26 Test #17: test-cuda-functions ..............   Passed    0.13 sec
      Start 18: test-cuda-indexing
18/26 Test #18: test-cuda-indexing ...............   Passed    0.10 sec
      Start 19: test-cuda-matmul
19/26 Test #19: test-cuda-matmul .................   Passed    0.20 sec
      Start 20: test-cuda-operations
20/26 Test #20: test-cuda-operations .............   Passed    0.15 sec
      Start 21: test-cuda-outer
21/26 Test #21: test-cuda-outer ..................   Passed    0.01 sec
      Start 22: test-cuda-reductions
22/26 Test #22: test-cuda-reductions .............   Passed    0.14 sec
      Start 23: test-cuda-repeats
23/26 Test #23: test-cuda-repeats ................   Passed    0.17 sec
      Start 24: test-layout
24/26 Test #24: test-layout ......................   Passed    0.00 sec
      Start 25: test-tensor
25/26 Test #25: test-tensor ......................   Passed    0.00 sec
      Start 26: test-types
26/26 Test #26: test-types .......................   Passed    0.00 sec

100% tests passed, 0 tests failed out of 26

Total Test time (real) =   1.56 sec
```

Consolidating the tests into fewer files will speed things up even further, but there is something to be said for separating different tests into separate sources.

-------

Also, changed `CMAKE_CUDA_ARCHITECTURES` to  `native` to automatically detect the appropriate compute capability for the user's GPU.